### PR TITLE
fix: Avoid empty instances for DescibeContainerInstances

### DIFF
--- a/pkg/client/ecs.go
+++ b/pkg/client/ecs.go
@@ -168,6 +168,9 @@ func (c *ECSClient) ListContainerInstances(ctx context.Context, cluster string) 
 		if err != nil {
 			return nil, err
 		}
+		if len(listOut.ContainerInstanceArns) == 0 {
+			break
+		}
 
 		descOut, err := c.client.DescribeContainerInstances(ctx, &ecs.DescribeContainerInstancesInput{
 			Cluster:            aws.String(cluster),


### PR DESCRIPTION
Since DescribeContainerInstances disallows empty `ContainerInstances` input.